### PR TITLE
Removes testcontainers(.org) from local and CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
             - build-and-test-fhirbridge
             - cache-in-ehrbase-m2-dependencies
             - cache-in-fhirbridge-m2-dependencies
-            - collect-fhirbride-unittest-results
+            # - collect-fhirbride-unittest-results
             - collect-fhirbridge-integrationtest-results
             - save-fhirbridge-test-results
             - save-jacoco-coverage-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,11 @@ version: 2.1
 # OVERVIEW - What this CI pipeline does:
 #
 # 1. So far this pipeline consists of one workflow only, which
-#    - compiles FHIR-bridge code
-#    - starts ehrbase & postgresql containers via testcontainers's
-#      Docker Compose Module during Maven's verify phase (`mvn clean verify`)
+#    - clones ehrbase repo
+#    - builds ehrbase server from develop branch
+#    - starts ehrbase server (postgresql db is included in used docker executor,
+#                             see executors section at the buttom)
+#    - builds FHIR-bridge code
 #    - runs (Java) integration tests
 #    - creates code coverage report w/ Jacoco
 #    - performes sonarcoud.io code analysis
@@ -44,18 +46,26 @@ jobs:
     
     build-and-test-fhirbridge:
         description: Build and test FHIR-bridge, analyze code, upload results to sonarcloud.io
-        executor: vm-ubuntu-1604
+        executor: docker-py3-java11-postgres
+        # executor: machine-ubuntu-2004
         steps:
             - checkout
+            - setup-database
+            - install-maven
+            - git-clone-ehrbase-repo
             - cache-out-fhirbridge-m2-dependencies
-            - mvn-clean-verify
+            - cache-out-ehrbase-m2-dependencies
+            - build-ehrbase
+            - start-ehrbase-server
+            - build-and-test-fhirbridge
+            - cache-in-ehrbase-m2-dependencies
             - cache-in-fhirbridge-m2-dependencies
             # - collect-fhirbride-unittest-results
-            - collect-fhirbridge-integrationtest-results
-            - save-fhirbridge-test-results
-            - save-jacoco-coverage-report
-            - sonarcloud/scan:
-                cache_version: 1
+            # - collect-fhirbridge-integrationtest-results
+            # - save-fhirbridge-test-results
+            # - save-jacoco-coverage-report
+            # - sonarcloud/scan:
+            #     cache_version: 1
 
 
 
@@ -73,39 +83,115 @@ commands:
     #    Y8a.    .a8P  Y8a.    .a8P   88    `888'    88  88    `888'    88   d8'        `8b   88     `8888  88      .a8P   Y8a     a8P
     #     `"Y8888Y"'    `"Y8888Y"'    88     `8'     88  88     `8'     88  d8'          `8b  88      `888  88888888Y"'     "Y88888P"
     
-    
-    mvn-clean-verify:
-        description: | 
-            Executes `mvn clean verify`
-            testcontainers(.org) dependency ensures that ehrbase server
-            and postgresql db are started before integration tests a run.
+    setup-database:
+        description: Setup ehrbase database
         steps:
-            - openjdk-install/openjdk:
-                version: 11
-            - install-maven
             - run:
+                name: Setup database
+                # background: true
+                command: |
+                    docker run  -d --name ehrdb \
+                                -e POSTGRES_USER=$POSTGRES_USER \
+                                -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -d \
+                                -e DISABLE_SECURITY=true \
+                                -p 5432:5432 ehrbaseorg/ehrbase-database-docker:11.5
+
+
+    git-clone-ehrbase-repo:
+        steps:
+            - run:
+                name: CLONE EHRBASE REPO
+                command: |
+                    git clone git@github.com:ehrbase/ehrbase.git
+                    ls -la
+
+
+    build-ehrbase:
+        steps:
+            - run:
+                name: BUILD EHRBASE SERVER
                 command: |
                     ls -la
-                    mvn --version
-                    java --version
-                    mvn clean verify
+                    cd ehrbase
+                    mvn package -Dmaven.javadoc.skip=true -Dmaven.test.skip
+
+
+    start-ehrbase-server:
+        steps:
+            - run:
+                name: START EHRBASE SERVER
+                background: true
+                command: |
+                    ls -la
+                    cd ehrbase
+                    EHRbase_VERSION=$(mvn -q -Dexec.executable="echo" \
+                                             -Dexec.args='${project.version}' \
+                                             --non-recursive exec:exec)
+                    echo ${EHRbase_VERSION}
+                    java -jar "application/target/application-0.13.0.jar" > log
+
+
+    build-and-test-fhirbridge:
+        description: | 
+            Executes `mvn clean verify`
+        steps:
+            - run:
+                name: WAIT FOR EHRBASE SERVER TO BE READY
+                command: |
+                  jps
+                  ls -la
+                  timeout=30
+                  while [ ! -f ehrbase/log ];
+                  do
+                    echo "Waiting for file ehrbase/log ..."
+                    if [ "$timeout" == 0 ]; then
+                      echo "ERROR: timed out while waiting for file ehrbase/log"
+                      exit 1
+                    fi
+                    sleep 1
+                    ((timeout--))
+                  done
+                  if ! tail -f ehrbase/log | timeout 30s grep -m 1 "Started EhrBase in"; then
+                    echo "WARNING: Did not see a startup message even after waiting 30s" >&2
+                  fi
+                  jps
+            - run:
+                name: BUILD FHIR-BRIDGE
+                command: |
+                    ls -la
+                    mvn clean verify -Dmaven.javadoc.skip=true
 
 
     cache-out-fhirbridge-m2-dependencies:
         steps:
-          - run:
-              name: Generate Cache Checksum for FHIR-bridge Dependencies
-              command: find . -name 'pom.xml' | sort | xargs cat > /tmp/fhirbridge_maven_cache_seed
-          - restore_cache:
-              key: fhirbridge-
+            - run:
+                name: Generate Cache Checksum for FHIR-bridge Dependencies
+                command: find . -name 'pom.xml' | sort | xargs cat > /tmp/fhirbridge_maven_cache_seed
+            - restore_cache:
+                key: fhirbridge-
 
 
     cache-in-fhirbridge-m2-dependencies:
         steps:
-          - save_cache:
-              key: fhirbridge-{{ checksum "/tmp/fhirbridge_maven_cache_seed" }}
-              paths:
-              - ~/.m2
+            - save_cache:
+                key: fhirbridge-{{ checksum "/tmp/fhirbridge_maven_cache_seed" }}
+                paths:
+                - ~/.m2
+    
+    cache-out-ehrbase-m2-dependencies:
+        steps:
+            - run:
+                name: Generate Cache Checksum for EHRbase Dependencies
+                command: find ~/projects/ehrbase -name 'pom.xml' | sort | xargs cat > /tmp/ehrbase_maven_cache_seed
+            - restore_cache:
+                key: EHRbase-v1-
+    
+    cache-in-ehrbase-m2-dependencies:
+        steps:
+            - save_cache:
+                key: EHRbase-v1-{{ checksum "/tmp/ehrbase_maven_cache_seed" }}
+                paths:
+                    - ~/.m2
 
 
     # collect-fhirbridge-unittest-results:
@@ -179,6 +265,8 @@ commands:
             - run: 
                 name: Install Maven tool
                 command: |
+                    sudo killall -9 apt-get || true
+                    sudo apt -y update
                     [ -f /usr/bin/mvn ] && echo "Maven is already installed." || sudo apt install maven -y
 
 
@@ -199,21 +287,46 @@ executors:
     docker-python3-java11:
         working_directory: ~/projects
         docker:
-            - image: circleci/python@sha256:e1c98a85c5ee62ac52a2779fe5abe2677f021c8e3158e4fb2d569c7b9c6ac073
+            # - image: circleci/python@sha256:e1c98a85c5ee62ac52a2779fe5abe2677f021c8e3158e4fb2d569c7b9c6ac073
+            - image: circleci/python:3.8.5-node-browsers
 
     docker-py3-java11-postgres:
         working_directory: ~/projects
         docker:
-            - image: circleci/python@sha256:e1c98a85c5ee62ac52a2779fe5abe2677f021c8e3158e4fb2d569c7b9c6ac073
+            - image: circleci/python:3.8.5-node-browsers
             - image: ehrbaseorg/ehrbase-postgres:10
               environment:
                 POSTGRES_USER: postgres
                 POSTGRES_PASSWORD: postgres
 
-    vm-ubuntu-1604:
+    machine-ubuntu-2004:
+        description: |
+            Ubuntu 20.04 VM (machine executor)
+            - openjdk 1.8
+            - openjdk 11.0.8 (default)
+            - maven 3.6.3
+            - gradle 6.6
+            - python 2.7.17
+            - python 3.8.5
+            - pip/pip3
+            - docker 19.03.12
+            - docker-compose 1.26.2
+            - aws-cli 2.0.43
+            - google cloud sdk 307.0.0
+            - heroku 7.42.12
+            - chrome 85.0.4183
+            - chromedriver 85.0.4183
+            - firefox 80.0.0
+            - go 1.15
+            - leiningen 2.9.4
+            - node 12.18.3 (default)
+            - node 14.8.0
+            - ruby 2.7.1
+            - sbt 1.3.13
+            - yarn 1.22.4
         working_directory: ~/projects
+        environment:
+            PIPELINE_ID: << pipeline.id >>
+            BRANCH_NAME: << pipeline.git.branch >>
         machine:
-            image: ubuntu-1604:202007-01        # what's inside:
-                                                # Ubuntu 16.04
-                                                # Docker v19.03.12
-                                                # Docker Compose v1.26.1
+            image: ubuntu-2004:202008-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
         # executor: machine-ubuntu-2004
         steps:
             - checkout
-            - setup-database
+            # - setup-database
             - install-maven
             - git-clone-ehrbase-repo
             - cache-out-fhirbridge-m2-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
         # executor: machine-ubuntu-2004
         steps:
             - checkout
-            # - setup-database
             - install-maven
             - git-clone-ehrbase-repo
             - cache-out-fhirbridge-m2-dependencies
@@ -60,12 +59,12 @@ jobs:
             - build-and-test-fhirbridge
             - cache-in-ehrbase-m2-dependencies
             - cache-in-fhirbridge-m2-dependencies
-            # - collect-fhirbride-unittest-results
-            # - collect-fhirbridge-integrationtest-results
-            # - save-fhirbridge-test-results
-            # - save-jacoco-coverage-report
-            # - sonarcloud/scan:
-            #     cache_version: 1
+            - collect-fhirbride-unittest-results
+            - collect-fhirbridge-integrationtest-results
+            - save-fhirbridge-test-results
+            - save-jacoco-coverage-report
+            - sonarcloud/scan:
+                cache_version: 1
 
 
 
@@ -83,18 +82,18 @@ commands:
     #    Y8a.    .a8P  Y8a.    .a8P   88    `888'    88  88    `888'    88   d8'        `8b   88     `8888  88      .a8P   Y8a     a8P
     #     `"Y8888Y"'    `"Y8888Y"'    88     `8'     88  88     `8'     88  d8'          `8b  88      `888  88888888Y"'     "Y88888P"
     
-    setup-database:
-        description: Setup ehrbase database
-        steps:
-            - run:
-                name: Setup database
-                # background: true
-                command: |
-                    docker run  -d --name ehrdb \
-                                -e POSTGRES_USER=$POSTGRES_USER \
-                                -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -d \
-                                -e DISABLE_SECURITY=true \
-                                -p 5432:5432 ehrbaseorg/ehrbase-database-docker:11.5
+    # setup-database:
+    #     description: Setup ehrbase database
+    #     steps:
+    #         - run:
+    #             name: Setup database
+    #             # background: true
+    #             command: |
+    #                 docker run  -d --name ehrdb \
+    #                             -e POSTGRES_USER=$POSTGRES_USER \
+    #                             -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -d \
+    #                             -e DISABLE_SECURITY=true \
+    #                             -p 5432:5432 ehrbaseorg/ehrbase-database-docker:11.5
 
 
     git-clone-ehrbase-repo:
@@ -138,23 +137,30 @@ commands:
             - run:
                 name: WAIT FOR EHRBASE SERVER TO BE READY
                 command: |
-                  jps
-                  ls -la
-                  timeout=30
-                  while [ ! -f ehrbase/log ];
-                  do
-                    echo "Waiting for file ehrbase/log ..."
-                    if [ "$timeout" == 0 ]; then
-                      echo "ERROR: timed out while waiting for file ehrbase/log"
-                      exit 1
-                    fi
-                    sleep 1
-                    ((timeout--))
-                  done
-                  if ! tail -f ehrbase/log | timeout 30s grep -m 1 "Started EhrBase in"; then
-                    echo "WARNING: Did not see a startup message even after waiting 30s" >&2
-                  fi
-                  jps
+                    jps
+                    ls -la
+                    timeout=30
+                    while [ ! -f ehrbase/log ];
+                        do
+                            echo "Waiting for file ehrbase/log ..."
+                            if [ "$timeout" == 0 ]; then
+                                echo "ERROR: timed out while waiting for file ehrbase/log"
+                                exit 1
+                            fi
+                            sleep 1
+                        ((timeout--))
+                    done
+                    while ! (cat ehrbase/log | grep -m 1 "Started EhrBase in");
+                        do
+                            echo "waiting for EHRbase to be ready ...";
+                            if [ "$timeout" == 0 ]; then
+                                echo "WARNING: Did not see a startup message even after waiting 30s"
+                                exit 1
+                            fi
+                            sleep 1;
+                        ((timeout--))
+                    done
+                    jps
             - run:
                 name: BUILD FHIR-BRIDGE
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
     build-and-test-fhirbridge:
         description: Build and test FHIR-bridge, analyze code, upload results to sonarcloud.io
         executor: docker-py3-java11-postgres
-        # executor: machine-ubuntu-2004
         steps:
             - checkout
             - install-maven
@@ -82,19 +81,6 @@ commands:
     #    Y8a.    .a8P  Y8a.    .a8P   88    `888'    88  88    `888'    88   d8'        `8b   88     `8888  88      .a8P   Y8a     a8P
     #     `"Y8888Y"'    `"Y8888Y"'    88     `8'     88  88     `8'     88  d8'          `8b  88      `888  88888888Y"'     "Y88888P"
     
-    # setup-database:
-    #     description: Setup ehrbase database
-    #     steps:
-    #         - run:
-    #             name: Setup database
-    #             # background: true
-    #             command: |
-    #                 docker run  -d --name ehrdb \
-    #                             -e POSTGRES_USER=$POSTGRES_USER \
-    #                             -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -d \
-    #                             -e DISABLE_SECURITY=true \
-    #                             -p 5432:5432 ehrbaseorg/ehrbase-database-docker:11.5
-
 
     git-clone-ehrbase-repo:
         steps:
@@ -137,7 +123,6 @@ commands:
             - run:
                 name: WAIT FOR EHRBASE SERVER TO BE READY
                 command: |
-                    jps
                     ls -la
                     timeout=30
                     while [ ! -f ehrbase/log ];
@@ -160,6 +145,7 @@ commands:
                             sleep 1;
                         ((timeout--))
                     done
+                    echo "REMAINING TIMEOUT: $timeout"
                     jps
             - run:
                 name: BUILD FHIR-BRIDGE
@@ -293,7 +279,6 @@ executors:
     docker-python3-java11:
         working_directory: ~/projects
         docker:
-            # - image: circleci/python@sha256:e1c98a85c5ee62ac52a2779fe5abe2677f021c8e3158e4fb2d569c7b9c6ac073
             - image: circleci/python:3.8.5-node-browsers
 
     docker-py3-java11-postgres:
@@ -304,35 +289,3 @@ executors:
               environment:
                 POSTGRES_USER: postgres
                 POSTGRES_PASSWORD: postgres
-
-    machine-ubuntu-2004:
-        description: |
-            Ubuntu 20.04 VM (machine executor)
-            - openjdk 1.8
-            - openjdk 11.0.8 (default)
-            - maven 3.6.3
-            - gradle 6.6
-            - python 2.7.17
-            - python 3.8.5
-            - pip/pip3
-            - docker 19.03.12
-            - docker-compose 1.26.2
-            - aws-cli 2.0.43
-            - google cloud sdk 307.0.0
-            - heroku 7.42.12
-            - chrome 85.0.4183
-            - chromedriver 85.0.4183
-            - firefox 80.0.0
-            - go 1.15
-            - leiningen 2.9.4
-            - node 12.18.3 (default)
-            - node 14.8.0
-            - ruby 2.7.1
-            - sbt 1.3.13
-            - yarn 1.22.4
-        working_directory: ~/projects
-        environment:
-            PIPELINE_ID: << pipeline.id >>
-            BRANCH_NAME: << pipeline.git.branch >>
-        machine:
-            image: ubuntu-2004:202008-01

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 ## Project setup
 
-### Prerequisites
-Docker installed.
-
 ### Build
 ```
 mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -219,30 +219,6 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.6.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <version>1.14.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>1.14.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${spring-boot.version}</version>

--- a/src/test/java/org/ehrbase/fhirbridge/FhirBridgeApplicationIT.java
+++ b/src/test/java/org/ehrbase/fhirbridge/FhirBridgeApplicationIT.java
@@ -17,15 +17,9 @@ import org.ehrbase.fhirbridge.fhir.Profile;
 import org.ehrbase.fhirbridge.rest.EhrbaseService;
 import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-// import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.containers.DockerComposeContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +28,6 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -46,16 +39,9 @@ import java.util.UUID;
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@Testcontainers
-public class FhirBridgeApplicationTestIT {
+public class FhirBridgeApplicationIT {
 
-        private final Logger logger = LoggerFactory.getLogger(FhirBridgeApplicationTestIT.class);
-
-        @Container
-        public static DockerComposeContainer environment = new DockerComposeContainer(
-                        new File("src/test/resources/ehrbase-compose.yml")).withExposedService("ehrdb", 5432)
-                                        .withExposedService("ehrbase", 8080)
-                                        .waitingFor("ehrbase", Wait.forListeningPort());
+        private final Logger logger = LoggerFactory.getLogger(FhirBridgeApplicationIT.class);
 
         @LocalServerPort
         private int port;


### PR DESCRIPTION
- Removed java testcontainers from build
- To execute integration tests locally ehrbase and postgresql db have to be started manually
- renamed testfile back to *IT.java since this is what the [maven failsafe plugin defaults to when including integration tests](https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#includes)
  **We should stick to this as a naming convention and rename integration tests in other projects (from `*TestIT.java`) to follow this convention**