### PR TITLE
NUM-504 / Happy Path Tests for Diagnosis Covid-19

### DIFF
--- a/src/test/resources/Condition/create-diagnosis-covid-19-absent.json
+++ b/src/test/resources/Condition/create-diagnosis-covid-19-absent.json
@@ -1,0 +1,82 @@
+{
+    "resourceType": "Condition",
+    "id": "018ed637-c0b3-4b6d-8b8f-e8686949cc7f",
+    "meta": {
+        "profile": [
+            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/diagnosis-covid-19"
+        ]
+    },
+    "clinicalStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active",
+                "display": "Active"
+            }
+        ]
+    },
+    "verificationStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "refuted",
+                "display": "Refuted"
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "code": "410594000",
+                "display": "Definitely NOT present (qualifier value)"
+            }
+        ]
+    },
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "394807007",
+                    "display": "Infectious diseases (specialty) (qualifier value)"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "840539006",
+                "display": "Disease caused by Severe acute respiratory syndrome coronavirus 2 (disorder)"
+            }
+        ]
+    },
+    "subject": {
+        "identifier": {
+            "system": "urn:ietf:rfc:4122",
+            "value": "{{patientId}}"
+        }
+    },
+    "recordedDate": "2020-10-23T12:48:23+02:00",
+    "stage": [
+        {
+            "summary": {
+                "coding": [
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "24484000",
+                        "display": "Severe (severity modifier) (qualifier value)"
+                    }
+                ],
+                "text": "Critical phase"
+            },
+            "type": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "88859-4",
+                        "display": "Disease stage score for risk calculation"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/test/resources/Condition/create-diagnosis-covid-19-present-active.json
+++ b/src/test/resources/Condition/create-diagnosis-covid-19-present-active.json
@@ -1,0 +1,82 @@
+{
+    "resourceType": "Condition",
+    "id": "018ed637-c0b3-4b6d-8b8f-e8686949cc7f",
+    "meta": {
+        "profile": [
+            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/diagnosis-covid-19"
+        ]
+    },
+    "clinicalStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active",
+                "display": "Active"
+            }
+        ]
+    },
+    "verificationStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed",
+                "display": "Confirmed"
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "code": "410605003",
+                "display": "Confirmed present (qualifier value)"
+            }
+        ]
+    },
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "394807007",
+                    "display": "Infectious diseases (specialty) (qualifier value)"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "840539006",
+                "display": "Disease caused by Severe acute respiratory syndrome coronavirus 2 (disorder)"
+            }
+        ]
+    },
+    "subject": {
+        "identifier": {
+            "system": "urn:ietf:rfc:4122",
+            "value": "{{patientId}}"
+        }
+    },
+    "recordedDate": "2020-10-23T12:48:23+02:00",
+    "stage": [
+        {
+            "summary": {
+                "coding": [
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "24484000",
+                        "display": "Severe (severity modifier) (qualifier value)"
+                    }
+                ],
+                "text": "Critical phase"
+            },
+            "type": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "88859-4",
+                        "display": "Disease stage score for risk calculation"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/test/resources/Condition/create-diagnosis-covid-19-present-remission.json
+++ b/src/test/resources/Condition/create-diagnosis-covid-19-present-remission.json
@@ -1,0 +1,82 @@
+{
+    "resourceType": "Condition",
+    "id": "018ed637-c0b3-4b6d-8b8f-e8686949cc7f",
+    "meta": {
+        "profile": [
+            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/diagnosis-covid-19"
+        ]
+    },
+    "clinicalStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "remission",
+                "display": "Remission"
+            }
+        ]
+    },
+    "verificationStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed",
+                "display": "Confirmed"
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "code": "410605003",
+                "display": "Confirmed present (qualifier value)"
+            }
+        ]
+    },
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "394807007",
+                    "display": "Infectious diseases (specialty) (qualifier value)"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "840539006",
+                "display": "Disease caused by Severe acute respiratory syndrome coronavirus 2 (disorder)"
+            }
+        ]
+    },
+    "subject": {
+        "identifier": {
+            "system": "urn:ietf:rfc:4122",
+            "value": "{{patientId}}"
+        }
+    },
+    "recordedDate": "2020-10-23T12:48:23+02:00",
+    "stage": [
+        {
+            "summary": {
+                "coding": [
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "24484000",
+                        "display": "Severe (severity modifier) (qualifier value)"
+                    }
+                ],
+                "text": "Critical phase"
+            },
+            "type": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "88859-4",
+                        "display": "Disease stage score for risk calculation"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/test/resources/Condition/create-diagnosis-covid-19-unknown.json
+++ b/src/test/resources/Condition/create-diagnosis-covid-19-unknown.json
@@ -1,0 +1,50 @@
+{
+    "resourceType": "Condition",
+    "id": "018ed637-c0b3-4b6d-8b8f-e8686949cc7f",
+    "meta": {
+        "profile": [
+            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/diagnosis-covid-19"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/uncertainty-of-presence",
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "261665006",
+                        "display": "Unknown (qualifier value)"
+                    }
+                ],
+                "text": "Presence of condition is unknown."
+            }
+        }
+    ],
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "394807007",
+                    "display": "Infectious diseases (specialty) (qualifier value)"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "840539006",
+                "display": "Disease caused by Severe acute respiratory syndrome coronavirus 2 (disorder)"
+            }
+        ]
+    },
+    "subject": {
+        "identifier": {
+            "system": "urn:ietf:rfc:4122",
+            "value": "{{patientId}}"
+        }
+    }
+}

--- a/src/test/resources/Condition/create-malignant-neoplastic-disease-absent.json
+++ b/src/test/resources/Condition/create-malignant-neoplastic-disease-absent.json
@@ -1,0 +1,50 @@
+{
+    "resourceType": "Condition",
+    "id": "21a249f8-280a-4741-a62c-ad0ca340cfb9",
+    "meta": {
+        "profile": [
+            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/malignant-neoplastic-disease"
+        ]
+    },
+    "verificationStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "refuted",
+                "display": "Refuted"
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "code": "410594000",
+                "display": "Definitely NOT present (qualifier value)"
+            }
+        ]
+    },
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "408475000",
+                    "display": "Diabetic medicine"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "363346000",
+                "display": "Malignant neoplastic disease"
+            }
+        ]
+    },
+    "subject": {
+        "identifier": {
+            "system": "urn:ietf:rfc:4122",
+            "value": "{{patientId}}"
+        }
+    },
+    "recordedDate": "2020-10-06"
+}

--- a/src/test/resources/Condition/create-malignant-neoplastic-disease-present-active.json
+++ b/src/test/resources/Condition/create-malignant-neoplastic-disease-present-active.json
@@ -1,0 +1,59 @@
+{
+    "resourceType": "Condition",
+    "id": "44d28692-497b-4366-b689-be9c704c30c7",
+    "meta": {
+        "profile": [
+            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/malignant-neoplastic-disease"
+        ]
+    },
+    "clinicalStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active",
+                "display": "Active"
+            }
+        ]
+    },
+    "verificationStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed",
+                "display": "Confirmed"
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "code": "410605003",
+                "display": "Confirmed present (qualifier value)"
+            }
+        ]
+    },
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "408475000",
+                    "display": "Diabetic medicine"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "363346000",
+                "display": "Malignant neoplastic disease"
+            }
+        ]
+    },
+    "subject": {
+        "identifier": {
+            "system": "urn:ietf:rfc:4122",
+            "value": "{{patientId}}"
+        }
+    },
+    "recordedDate": "2020-10-06"
+}

--- a/src/test/resources/Condition/create-malignant-neoplastic-disease-present-remission.json
+++ b/src/test/resources/Condition/create-malignant-neoplastic-disease-present-remission.json
@@ -1,0 +1,59 @@
+{
+    "resourceType": "Condition",
+    "id": "5743b814-eaa6-4ce2-b629-5490bdf17659",
+    "meta": {
+        "profile": [
+            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/malignant-neoplastic-disease"
+        ]
+    },
+    "clinicalStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "remission",
+                "display": "Remission"
+            }
+        ]
+    },
+    "verificationStatus": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed",
+                "display": "Confirmed"
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "code": "410605003",
+                "display": "Confirmed present (qualifier value)"
+            }
+        ]
+    },
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "408475000",
+                    "display": "Diabetic medicine"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "363346000",
+                "display": "Malignant neoplastic disease"
+            }
+        ]
+    },
+    "subject": {
+        "identifier": {
+            "system": "urn:ietf:rfc:4122",
+            "value": "{{patientId}}"
+        }
+    },
+    "recordedDate": "2020-10-06"
+}

--- a/src/test/resources/Condition/create-malignant-neoplastic-disease-unknown.json
+++ b/src/test/resources/Condition/create-malignant-neoplastic-disease-unknown.json
@@ -1,0 +1,51 @@
+{
+    "resourceType": "Condition",
+    "id": "2d8aed72-6a97-489e-8980-73f45bae024d",
+    "meta": {
+        "profile": [
+            "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/malignant-neoplastic-disease"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/uncertainty-of-presence",
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "261665006",
+                        "display": "Unknown (qualifier value)"
+                    }
+                ],
+                "text": "Presence of condition is unknown."
+            }
+        }
+    ],
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "408475000",
+                    "display": "Diabetic medicine"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "363346000",
+                "display": "Malignant neoplastic disease"
+            }
+        ]
+    },
+    "subject": {
+        "identifier": {
+            "system": "urn:ietf:rfc:4122",
+            "value": "{{patientId}}"
+        }
+    },
+    "recordedDate": "2020-10-06"
+}

--- a/tests/robot/CONDITION/01_create.robot
+++ b/tests/robot/CONDITION/01_create.robot
@@ -408,7 +408,7 @@ Force Tags              create
     condition.create diagnosis covid-19    create-diagnosis-covid-19-present-remission.json
     condition.validate response - 201
 
-# TODO: CLARIFY IF UNKNOW STAUTUS FOR DIAGNOSIS MAKES SENSE
+# TODO: CLARIFY IF UNKNOW STATUS FOR DIAGNOSIS MAKES SENSE
 032 Create Diagnosis Covid-19 (Unknown)
 	[Documentation]    1. create new EHR Patient record
 	...                2. update {{patient_id}} in example json
@@ -417,5 +417,5 @@ Force Tags              create
     [Tags]             diagnosis-covid-19    valid    not-ready   xxx
 
     ehr.create new ehr    000_ehr_status.json
-    condition.create diagnosis covid-19    create-diagnosis-covid-19-unknow.json
+    condition.create diagnosis covid-19    create-diagnosis-covid-19-unknown.json
     condition.validate response - 201

--- a/tests/robot/CONDITION/01_create.robot
+++ b/tests/robot/CONDITION/01_create.robot
@@ -35,8 +35,8 @@ Force Tags              create
 *** Test Cases ***
 001 Create Diagnose Condition
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
     [Tags]              diagnose-condition    valid
 
@@ -47,7 +47,7 @@ Force Tags              create
 
 002 Create Condition Using Invalid Profile
     [Documentation]     1. create EHR
-    ...                 2. trigger condition endpoint using invalid payload
+    ...                 2. POST to Condition endpoint using invalid profile
     [Tags]              invalid
 
     ehr.create new ehr    000_ehr_status.json
@@ -55,9 +55,9 @@ Force Tags              create
     condition.validate response - 422 (Unprocessable Entity)
 
 
-003 Create Condition Symptoms-Covid-19 Present
+003 Create Condition Symptoms-Covid-19 (Present)
     [Documentation]     1. create EHR
-    ...                 2. create condition symptos-covid-19 present
+    ...                 2. create condition symptoms-covid-19 (status: present)
     [Tags]              symptoms-covid-19    valid
 
     ehr.create new ehr    000_ehr_status.json
@@ -65,9 +65,9 @@ Force Tags              create
     condition.validate response - 201
 
 
-004 Create Condition Symptoms-Covid-19 Absent
+004 Create Condition Symptoms-Covid-19 (Absent)
     [Documentation]     1. create EHR
-    ...                 2. create condition symptos-covid-19 present
+    ...                 2. create condition symptoms-covid-19 (status: absent)
     [Tags]              symptoms-covid-19    valid
 
     ehr.create new ehr    000_ehr_status.json
@@ -75,9 +75,9 @@ Force Tags              create
     condition.validate response - 201
 
 
-005 Create Condition Symptoms-Covid-19 Unknown
+005 Create Condition Symptoms-Covid-19 (Unknown)
     [Documentation]     1. create EHR
-    ...                 2. create condition symptos-covid-19 present
+    ...                 2. create condition symptoms-covid-19 (status: unknown)
     [Tags]              symptoms-covid-19    valid
 
     ehr.create new ehr    000_ehr_status.json
@@ -87,8 +87,8 @@ Force Tags              create
 
 006 Create Condition Diabetes Mellitus
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
     [Tags]             diabetes-mellitus    valid    not-ready
 
@@ -99,8 +99,8 @@ Force Tags              create
 
 007 Create Condition Diabetes Mellitus Type 1
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
     [Tags]             diabetes-mellitus    valid    not-ready
 
@@ -111,8 +111,8 @@ Force Tags              create
 
 008 Create Condition Diabetes Mellitus Type 2
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
     [Tags]             diabetes-mellitus    valid    not-ready
 
@@ -123,8 +123,8 @@ Force Tags              create
 
 009 Create Condition Diabetes Mellitus Type 2 Insulin Treated
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
     [Tags]             diabetes-mellitus    valid    not-ready
 
@@ -135,8 +135,8 @@ Force Tags              create
 
 010 Create Rheumatological Immunological Diseases (Rheumatism)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
     [Tags]             diabetes-mellitus    valid    not-ready
 
@@ -147,8 +147,8 @@ Force Tags              create
 
 011 Create Rheumatological Immunological Diseases (Rheumatoid Arthritis)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
     [Tags]             diabetes-mellitus    valid    not-ready
 
@@ -159,10 +159,10 @@ Force Tags              create
 
 012 Create Chronic Lung Diseases
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-lung-diseases    valid    not-ready
+    [Tags]             chronic-lung-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic lung diseases    Chronic lung disease    create-chronic-lung-disease.json
@@ -171,10 +171,10 @@ Force Tags              create
 
 013 Create Chronic Obstructive Lung Disease
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-lung-diseases    valid    not-ready
+    [Tags]             chronic-lung-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic lung diseases    Chronic obstructive lung disease    create-chronic-obstructive-lung-disease.json
@@ -183,10 +183,10 @@ Force Tags              create
 
 014 Create Chronic Lung Disease (Fibrosis of Lung)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-lung-diseases    valid    not-ready
+    [Tags]             chronic-lung-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic lung diseases    Chronic Lung Disease (Fibrosis of Lung)    create-chronic-lung-disease-fibrosis-of-lung.json
@@ -195,10 +195,10 @@ Force Tags              create
 
 015 Create Chronic Lung Disease (Asthma)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-lung-diseases    valid    not-ready
+    [Tags]             chronic-lung-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic lung diseases    Chronic Lung Disease (Asthma)    create-chronic-lung-disease-asthma.json
@@ -207,10 +207,10 @@ Force Tags              create
 
 016 Create Chronic Lung Disease (Cystic Fibrosis)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-lung-diseases    valid    not-ready
+    [Tags]             chronic-lung-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic lung diseases    Chronic Lung Disease (Cystic Fibrosis)    create-chronic-lung-disease-cystic-fibrosis.json
@@ -219,10 +219,10 @@ Force Tags              create
 
 017 Create Chronic Lung Disease (Extreme Obesity with Alveolar Hypoventilation)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-lung-diseases    valid    not-ready
+    [Tags]             chronic-lung-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic lung diseases    Chronic Lung Disease (Extreme Obesity with Alveolar Hypoventilation)    create-chronic-lung-disease-with-alveolar-hypoventilation.json
@@ -231,10 +231,10 @@ Force Tags              create
 
 018 Create Chronic Lung Disease (Pulmonary hypertension)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-lung-diseases    valid    not-ready
+    [Tags]             chronic-lung-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic lung diseases    Chronic Lung Disease (Pulmonary hypertension)    create-chronic-lung-disease-pulmonary-hypertension.json
@@ -243,10 +243,10 @@ Force Tags              create
 
 019 Create Chronic Lung Disease (Sleep Apnea)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-lung-diseases    valid    not-ready
+    [Tags]             chronic-lung-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic lung diseases    Chronic Lung Disease (Sleep Apnea)    create-chronic-lung-disease-sleep-apnea.json
@@ -255,10 +255,10 @@ Force Tags              create
 
 020 Create Chronic Lung Disease (Obstructive Sleep Apnea Syndrome)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-lung-diseases    valid    not-ready
+    [Tags]             chronic-lung-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic lung diseases    Chronic Lung Disease (Obstructive Sleep Apnea Syndrome)    create-chronic-lung-disease-obstructive-sleep-apnea.json
@@ -267,10 +267,10 @@ Force Tags              create
 
 021 Create Chronic Liver Disease
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-liver-diseases    valid    not-ready
+    [Tags]             chronic-liver-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic liver diseases    Chronic Liver Disease    create-chronic-liver-disease.json
@@ -279,10 +279,10 @@ Force Tags              create
 
 022 Create Chronic Liver Disease (Autoimmune Liver Disease)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-liver-diseases    valid    not-ready
+    [Tags]             chronic-liver-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic liver diseases    Chronic Liver Disease (Autoimmune Liver Disease)    create-chronic-liver-disease-autoimmune.json
@@ -291,10 +291,10 @@ Force Tags              create
 
 023 Create Chronic Liver Disease (Chronic Viral Hepatitis)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-liver-diseases    valid    not-ready
+    [Tags]             chronic-liver-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic liver diseases    Chronic Liver Disease (Chronic Viral Hepatitis)    create-chronic-liver-disease-chronic-viral-hepatitis.json
@@ -303,10 +303,10 @@ Force Tags              create
 
 024 Create Chronic Liver Disease (Cirrhosis of Liver)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-liver-diseases    valid    not-ready
+    [Tags]             chronic-liver-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic liver diseases    Chronic Liver Disease (Cirrhosis of Liver)    create-chronic-liver-disease-cirrhosis-of-liver.json
@@ -315,11 +315,59 @@ Force Tags              create
 
 025 Create Chronic Liver Disease (Steatosis of Liver)
 	[Documentation]    1. create new EHR Patient record
-	...                2. update example json patient id
-    ...                3. post example json to observation endpoint
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
 	...                4. validate the response status
-    [Tags]             chronic-liver-diseases    valid    not-ready
+    [Tags]             chronic-liver-disease    valid    not-ready
 
     ehr.create new ehr    000_ehr_status.json
     condition.create chronic liver diseases    Chronic Liver Disease (Steatosis of Liver)    create-chronic-liver-disease-steatosis-of-liver.json
+    condition.validate response - 201
+
+
+026 Create Malignant Neoplastic Disease (Absent)
+	[Documentation]    1. create new EHR Patient record
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
+	...                4. validate the response status
+    [Tags]             malignant-neoplastic-disease    valid    not-ready
+
+    ehr.create new ehr    000_ehr_status.json
+    condition.create malignant neoplastic disease    create-malignant-neoplastic-disease-absent.json
+    condition.validate response - 201
+
+
+027 Create Malignant Neoplastic Disease (Present Active)
+	[Documentation]    1. create new EHR Patient record
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
+	...                4. validate the response status
+    [Tags]             malignant-neoplastic-disease    valid    not-ready
+
+    ehr.create new ehr    000_ehr_status.json
+    condition.create malignant neoplastic disease    create-malignant-neoplastic-disease-present-active.json
+    condition.validate response - 201
+
+
+028 Create Malignant Neoplastic Disease (Present Remission)
+	[Documentation]    1. create new EHR Patient record
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
+	...                4. validate the response status
+    [Tags]             malignant-neoplastic-disease    valid    not-ready
+
+    ehr.create new ehr    000_ehr_status.json
+    condition.create malignant neoplastic disease    create-malignant-neoplastic-disease-present-remission.json
+    condition.validate response - 201
+
+
+029 Create Malignant Neoplastic Disease (Unknown)
+	[Documentation]    1. create new EHR Patient record
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
+	...                4. validate the response status
+    [Tags]             malignant-neoplastic-disease    valid    not-ready
+
+    ehr.create new ehr    000_ehr_status.json
+    condition.create malignant neoplastic disease    create-malignant-neoplastic-disease-unknown.json
     condition.validate response - 201

--- a/tests/robot/CONDITION/01_create.robot
+++ b/tests/robot/CONDITION/01_create.robot
@@ -371,3 +371,51 @@ Force Tags              create
     ehr.create new ehr    000_ehr_status.json
     condition.create malignant neoplastic disease    create-malignant-neoplastic-disease-unknown.json
     condition.validate response - 201
+
+
+030 Create Diagnosis Covid-19 (Absent)
+	[Documentation]    1. create new EHR Patient record
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
+	...                4. validate the response status
+    [Tags]             diagnosis-covid-19    valid    not-ready   xxx
+
+    ehr.create new ehr    000_ehr_status.json
+    condition.create diagnosis covid-19    create-diagnosis-covid-19-absent.json
+    condition.validate response - 201
+
+
+031 Create Diagnosis Covid-19 (Present Active)
+	[Documentation]    1. create new EHR Patient record
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
+	...                4. validate the response status
+    [Tags]             diagnosis-covid-19    valid    not-ready   xxx
+
+    ehr.create new ehr    000_ehr_status.json
+    condition.create diagnosis covid-19    create-diagnosis-covid-19-present-active.json
+    condition.validate response - 201
+
+
+032 Create Diagnosis Covid-19 (Present Remission)
+	[Documentation]    1. create new EHR Patient record
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
+	...                4. validate the response status
+    [Tags]             diagnosis-covid-19    valid    not-ready   xxx
+
+    ehr.create new ehr    000_ehr_status.json
+    condition.create diagnosis covid-19    create-diagnosis-covid-19-present-remission.json
+    condition.validate response - 201
+
+# TODO: CLARIFY IF UNKNOW STAUTUS FOR DIAGNOSIS MAKES SENSE
+032 Create Diagnosis Covid-19 (Unknown)
+	[Documentation]    1. create new EHR Patient record
+	...                2. update {{patient_id}} in example json
+    ...                3. POST example json to Condition endpoint
+	...                4. validate the response status
+    [Tags]             diagnosis-covid-19    valid    not-ready   xxx
+
+    ehr.create new ehr    000_ehr_status.json
+    condition.create diagnosis covid-19    create-diagnosis-covid-19-unknow.json
+    condition.validate response - 201

--- a/tests/robot/_resources/keywords/condition.robot
+++ b/tests/robot/_resources/keywords/condition.robot
@@ -104,6 +104,11 @@ create malignant neoplastic disease
     POST /Condition with ehr reference    Malignant Neoplastic Disease    ${example_json}
 
 
+create diagnosis covid-19
+    [Arguments]         ${example_json}
+    POST /Condition with ehr reference    Diagnosis Covid-19    ${example_json}
+
+
 
 #                                   .                    
 #                                 .o8                    

--- a/tests/robot/_resources/keywords/condition.robot
+++ b/tests/robot/_resources/keywords/condition.robot
@@ -99,6 +99,12 @@ create chronic liver diseases
     POST /Condition with ehr reference    ${text}    ${example_json}
 
 
+create malignant neoplastic disease
+    [Arguments]         ${example_json}
+    POST /Condition with ehr reference    Malignant Neoplastic Disease    ${example_json}
+
+
+
 #                                   .                    
 #                                 .o8                    
 # oo.ooooo.   .ooooo.   .oooo.o .o888oo                  


### PR DESCRIPTION
Adds happy path test cases for

- Diagnosis Covid-19 (Absent)
- Diagnosis Covid-19 (Present Active)
- Diagnosis Covid-19 (Present Remission)
- Diagnosis Covid-19 (Unknown)

NOTE: tests are tagged as `not-ready` and the content of example JSONs may be wrong but that's what I've got from simplifier.net