### PR TITLE
added data sets for smoking status #223

### DIFF
--- a/src/test/resources/Observation/create-smoking-status-datetime.json
+++ b/src/test/resources/Observation/create-smoking-status-datetime.json
@@ -1,0 +1,47 @@
+{
+  "resourceType": "Observation",
+  "id": "smoking-status",
+  "meta": {
+    "profile": [
+      "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/smoking-status"
+    ]
+  },
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "social-history",
+          "display": "Social History"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "72166-2",
+        "display": "Tobacco smoking status"
+      }
+    ]
+  },
+  "subject": {
+    "identifier": {
+      "system": "urn:ietf:rfc:4122",
+      "value": "{{patientId}}"
+    }
+  },
+  "effectiveDateTime": "2020-09-21",
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "LA18978-9",
+        "display": "Never smoker"
+      }
+    ],
+    "text": "Patient is nonsmoker"
+  }
+}

--- a/src/test/resources/Observation/create-smoking-status-effective-absent.json
+++ b/src/test/resources/Observation/create-smoking-status-effective-absent.json
@@ -1,0 +1,52 @@
+{
+  "resourceType": "Observation",
+  "id": "smoking-status",
+  "meta": {
+    "profile": [
+      "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/smoking-status"
+    ]
+  },
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "social-history",
+          "display": "Social History"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "72166-2",
+        "display": "Tobacco smoking status"
+      }
+    ]
+  },
+  "subject": {
+    "identifier": {
+      "system": "urn:ietf:rfc:4122",
+      "value": "{{patientId}}"
+    }
+  },
+  "_effectiveDateTime": {
+    "extension": [{
+      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+      "valueCode": "unknown"
+    }]
+  },
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "LA18978-9",
+        "display": "Never smoker"
+      }
+    ],
+    "text": "Patient is nonsmoker"
+  }
+}


### PR DESCRIPTION
@af-pwo the datetime example is the same as the one we already have, I didn't delete the current one to avoid breaking robot test, but that should be deleted or renamed IMO.