### PR TITLE
NUM-1061 Parallel Test Execution With 'Pabot'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,8 +313,9 @@ jobs:
         executor: machine-ubuntu-2004
         steps:
             - checkout
-            - install-maven
+            # - install-maven                     # not needed on machine executor
             - restore-fhirbridge-workspace
+            - start-ehrbase-database              # needed on machine executor only
             - start-ehrbase-server
             - start-fhirbridge-application
             - run-robot-integration-tests:
@@ -486,6 +487,17 @@ commands:
                 command: |
                     git clone git@github.com:ehrbase/ehrbase.git
                     ls -la
+
+    start-ehrbase-database:
+        steps:
+            - run:
+                name: Start ehrbase postgres database
+                command: |
+                    docker run  -d --name ehrdb \
+                                -e POSTGRES_USER=$POSTGRES_USER \
+                                -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -d \
+                                -e DISABLE_SECURITY=true \
+                                -p 5432:5432 ehrbase/ehrbase-postgres:latest
 
 
     build-ehrbase:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,6 +498,7 @@ commands:
                                 -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -d \
                                 -e DISABLE_SECURITY=true \
                                 -p 5432:5432 ehrbase/ehrbase-postgres:latest
+                    sleep 1
 
 
     build-ehrbase:
@@ -584,6 +585,34 @@ commands:
 
     start-fhirbridge-application:
         steps:
+            - run:
+                name: WAIT FOR EHRBASE SERVER TO BE READY
+                command: |
+                    ls -la
+                    timeout=180
+                    while [ ! -f ehrbase/log ];
+                        do
+                            echo "Waiting for file ehrbase/log ..."
+                            if [ "$timeout" == 0 ]; then
+                                echo "ERROR: timed out while waiting for file ehrbase/log"
+                                exit 1
+                            fi
+                            sleep 1
+                        ((timeout--))
+                    done
+                    while ! (cat ehrbase/log | grep -m 1 "Started EhrBase in");
+                        do
+                            echo "waiting for EHRbase to be ready ...";
+                            if [ "$timeout" == 0 ]; then
+                                echo "WARNING: Did not see a startup message even after waiting 180s"
+                                cat ehrbase/log
+                                exit 1
+                            fi
+                            sleep 1;
+                        ((timeout--))
+                    done
+                    echo "REMAINING TIMEOUT: $timeout"
+                    jps
             - run:
                 name: START FHIRBRIDGE APPLICATION
                 background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,46 +40,46 @@ workflows:
                     branches:
                         ignore: gh-pages
 
-            # Execute Robot Integration Tests (Parallel Execution)
-            - BUNDLE-tests:
-                context: org-global
-                requires:
-                    - build-test-analyse-fhirbridge
-                filters:
-                    branches:
-                        ignore: gh-pages
+            # # Execute Robot Integration Tests (Parallel Execution)
+            # - BUNDLE-tests:
+            #     context: org-global
+            #     requires:
+            #         - build-test-analyse-fhirbridge
+            #     filters:
+            #         branches:
+            #             ignore: gh-pages
 
-            - CONDITION-tests:
-                context: org-global
-                requires:
-                    - build-test-analyse-fhirbridge
-                filters:
-                    branches:
-                        ignore: gh-pages
+            # - CONDITION-tests:
+            #     context: org-global
+            #     requires:
+            #         - build-test-analyse-fhirbridge
+            #     filters:
+            #         branches:
+            #             ignore: gh-pages
             
-            - DIAGNOSTIC-tests:
-                context: org-global
-                requires:
-                    - build-test-analyse-fhirbridge
-                filters:
-                    branches:
-                        ignore: gh-pages
+            # - DIAGNOSTIC-tests:
+            #     context: org-global
+            #     requires:
+            #         - build-test-analyse-fhirbridge
+            #     filters:
+            #         branches:
+            #             ignore: gh-pages
             
-            - IMMUNIZATION-tests:
-                context: org-global
-                requires:
-                    - build-test-analyse-fhirbridge
-                filters:
-                    branches:
-                        ignore: gh-pages
+            # - IMMUNIZATION-tests:
+            #     context: org-global
+            #     requires:
+            #         - build-test-analyse-fhirbridge
+            #     filters:
+            #         branches:
+            #             ignore: gh-pages
 
-            - MEDICATIONSTATEMENT-tests:
-                context: org-global
-                requires:
-                    - build-test-analyse-fhirbridge
-                filters:
-                    branches:
-                        ignore: gh-pages
+            # - MEDICATIONSTATEMENT-tests:
+            #     context: org-global
+            #     requires:
+            #         - build-test-analyse-fhirbridge
+            #     filters:
+            #         branches:
+            #             ignore: gh-pages
             
             - OBSERVATION-tests:
                 context: org-global
@@ -89,33 +89,33 @@ workflows:
                     branches:
                         ignore: gh-pages
             
-            - PROCEDURE-tests:
-                context: org-global
-                requires:
-                    - build-test-analyse-fhirbridge
-                filters:
-                    branches:
-                        ignore: gh-pages
+            # - PROCEDURE-tests:
+            #     context: org-global
+            #     requires:
+            #         - build-test-analyse-fhirbridge
+            #     filters:
+            #         branches:
+            #             ignore: gh-pages
             
-            - QUESTIONAIRE-tests:
-                context: org-global
-                requires:
-                    - build-test-analyse-fhirbridge
-                filters:
-                    branches:
-                        ignore: gh-pages
+            # - QUESTIONAIRE-tests:
+            #     context: org-global
+            #     requires:
+            #         - build-test-analyse-fhirbridge
+            #     filters:
+            #         branches:
+            #             ignore: gh-pages
             
             - ROBOT-TEST-REPORT:
                 context: org-global
                 requires:
-                    - BUNDLE-tests
-                    - CONDITION-tests
-                    - DIAGNOSTIC-tests
-                    - IMMUNIZATION-tests
-                    - MEDICATIONSTATEMENT-tests
+                    # - BUNDLE-tests
+                    # - CONDITION-tests
+                    # - DIAGNOSTIC-tests
+                    # - IMMUNIZATION-tests
+                    # - MEDICATIONSTATEMENT-tests
                     - OBSERVATION-tests
-                    - PROCEDURE-tests
-                    - QUESTIONAIRE-tests
+                    # - PROCEDURE-tests
+                    # - QUESTIONAIRE-tests
 
 
             - tag-version:
@@ -309,7 +309,8 @@ jobs:
     OBSERVATION-tests:
         description: |
             todo
-        executor: docker-py3-java11-postgres
+        # executor: docker-py3-java11-postgres
+        executor: machine-ubuntu-2004
         steps:
             - checkout
             - install-maven
@@ -320,8 +321,8 @@ jobs:
                 include-tags: "observation"
                 test-suite-path: "OBSERVATION"
                 test-suite-name: "OBSERVATION"
-                runner: robot
-                pabot-split: ""
+                runner: pabot
+                pabot-split: "--testlevelsplit"
             - save-fhirbridge-robot-test-results
 
     PROCEDURE-tests:
@@ -952,4 +953,36 @@ executors:
             #   environment:
             #     POSTGRES_USER: fhir_bridge
             #     POSTGRES_PASSWORD: fhir_bridge
-        # resource_class: large
+        resource_class: large
+
+    machine-ubuntu-2004:
+        description: |
+            Ubuntu 20.04 VM (machine executor)
+            - openjdk 1.8
+            - openjdk 11.0.8 (default)
+            - maven 3.6.3
+            - gradle 6.6
+            - python 2.7.17
+            - python 3.8.5
+            - pip/pip3
+            - docker 19.03.12
+            - docker-compose 1.26.2
+            - aws-cli 2.0.43
+            - google cloud sdk 307.0.0
+            - heroku 7.42.12
+            - chrome 85.0.4183
+            - chromedriver 85.0.4183
+            - firefox 80.0.0
+            - go 1.15
+            - leiningen 2.9.4
+            - node 12.18.3 (default)
+            - node 14.8.0
+            - ruby 2.7.1
+            - sbt 1.3.13
+            - yarn 1.22.4
+        working_directory: ~/projects
+        environment:
+            PIPELINE_ID: << pipeline.id >>
+            BRANCH_NAME: << pipeline.git.branch >>
+        machine:
+            image: ubuntu-2004:202008-01


### PR DESCRIPTION
Introduces [pabot](https://github.com/mkorpela/pabot) as test dependency for parallel test execution

- parallelisation happens on test case level and is limited to the amount of available CPU cores/threads (execution time saving depends highly on amount of CPU cores, i.e. on a machine with 24 CPU cores 24 tests are executed simultaneously)
- since CircleCI's default docker executors has 2 vCPU cores only, it is best to configure a higher resource_class (i.e. large) to take a notice of any parallelisation effect (NOTE: resource_classes other than default require a paid plan on CircleCI)
- execution time saving using resource_class=large (4 x vCPU) is about 50% (~ 10 min vs. ~20 - 30 min)

:information_source:  Check original PR https://github.com/ehrbase/fhir-bridge/pull/245 for more details.

