### PR TITLE
Fixed bug in patient mapping when Age extension is missing

### DIFF
--- a/src/main/java/org/ehrbase/fhirbridge/ehr/converter/generic/PatientToCompositionConverter.java
+++ b/src/main/java/org/ehrbase/fhirbridge/ehr/converter/generic/PatientToCompositionConverter.java
@@ -7,6 +7,7 @@ import org.hl7.fhir.r4.model.Patient;
 import org.springframework.lang.NonNull;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 
 public abstract class PatientToCompositionConverter<C extends CompositionEntity> extends CompositionConverter<Patient, C> {
@@ -14,14 +15,8 @@ public abstract class PatientToCompositionConverter<C extends CompositionEntity>
     @Override
     public C convert(@NonNull Patient resource) {
         C composition = super.convert(resource);
-        if (resource.hasExtension() && resource.hasBirthDate()) {
-            Extension extensionAge = resource.getExtensionByUrl("https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/age");
-            DateTimeType dateTimeOfDocumentationDt = (DateTimeType) extensionAge.getExtensionByUrl("dateTimeOfDocumentation").getValue();
-            ZonedDateTime dateTimeOfDocumentation = dateTimeOfDocumentationDt.getValueAsCalendar().toZonedDateTime();
-            composition.setStartTimeValue(dateTimeOfDocumentation);
-        } else {
-            composition.setStartTimeValue(Instant.now());
-        }
+        Extension extensionAge = resource.getExtensionByUrl("https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/age");
+        composition.setStartTimeValue(TimeConverter.convertAgeExtensionTime(extensionAge));
         return composition;
     }
 }

--- a/src/main/java/org/ehrbase/fhirbridge/ehr/converter/generic/TimeConverter.java
+++ b/src/main/java/org/ehrbase/fhirbridge/ehr/converter/generic/TimeConverter.java
@@ -2,12 +2,13 @@ package org.ehrbase.fhirbridge.ehr.converter.generic;
 
 import org.hl7.fhir.r4.model.Condition;
 import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.MedicationStatement;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Procedure;
 import org.hl7.fhir.r4.model.QuestionnaireResponse;
-
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAccessor;
@@ -129,5 +130,17 @@ public class TimeConverter {
         } else {
             return OffsetDateTime.now();
         }
+    }
+
+    public static TemporalAccessor convertAgeExtensionTime(Extension extension) {
+        if (extension == null) {
+            return OffsetDateTime.now();
+        }
+        Extension dataTimeOfDocumentationExtension = extension.getExtensionByUrl("dateTimeOfDocumentation");
+        if (dataTimeOfDocumentationExtension == null) {
+            return OffsetDateTime.now();
+        }
+        DateTimeType dateTimeOfDocumentationDt = (DateTimeType) dataTimeOfDocumentationExtension.getValue();
+        return dateTimeOfDocumentationDt.getValueAsCalendar().toZonedDateTime();
     }
 }

--- a/src/main/java/org/ehrbase/fhirbridge/ehr/converter/specific/patient/AlterObservationConverter.java
+++ b/src/main/java/org/ehrbase/fhirbridge/ehr/converter/specific/patient/AlterObservationConverter.java
@@ -2,6 +2,7 @@ package org.ehrbase.fhirbridge.ehr.converter.specific.patient;
 
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import org.ehrbase.fhirbridge.ehr.converter.generic.EntryEntityConverter;
+import org.ehrbase.fhirbridge.ehr.converter.generic.TimeConverter;
 import org.ehrbase.fhirbridge.ehr.opt.geccopersonendatencomposition.definition.AlterObservation;
 
 import org.hl7.fhir.r4.model.Age;
@@ -11,6 +12,7 @@ import org.hl7.fhir.r4.model.Patient;
 
 import java.time.Period;
 import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
 
 public class AlterObservationConverter extends EntryEntityConverter<Patient, AlterObservation> {
 
@@ -18,14 +20,12 @@ public class AlterObservationConverter extends EntryEntityConverter<Patient, Alt
     protected AlterObservation convertInternal(Patient resource) {
         AlterObservation age = new AlterObservation();
         Extension extensionAge = resource.getExtensionByUrl("https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/age");
-        DateTimeType dateTimeOfDocumentationDt = (DateTimeType) extensionAge.getExtensionByUrl("dateTimeOfDocumentation").getValue();
-        ZonedDateTime dateTimeOfDocumentation = dateTimeOfDocumentationDt.getValueAsCalendar().toZonedDateTime();
-
-        //TODO refactor
-        age.setOriginValue(dateTimeOfDocumentation);
-        age.setTimeValue(dateTimeOfDocumentation);
-        //age - Alter (ISO8601 duration e.g. P67Y)
-        age.setAlterValue(getAge(extensionAge));
+        if (extensionAge != null) {
+            TemporalAccessor time = TimeConverter.convertAgeExtensionTime(extensionAge); //should be sth. generic in TimeConverter?
+            age.setOriginValue(time);
+            age.setTimeValue(time);
+            age.setAlterValue(getAge(extensionAge));
+        }
         return age;
     }
 


### PR DESCRIPTION
Fixed bug in patient mapping when Age extension is missing and refactored dataTime conversion into TimeConverter class. 

This should fix #281

