### PR TITLE
downgrade CircleCI resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -952,4 +952,4 @@ executors:
             #   environment:
             #     POSTGRES_USER: fhir_bridge
             #     POSTGRES_PASSWORD: fhir_bridge
-        resource_class: large
+        # resource_class: large


### PR DESCRIPTION
fhir-bridge ci pipeline consumes too much of circleci credits. this will reduce it without extending pipeline runtime (see last build, same round about 40 minutes)