### PR TITLE
exclude xpp3 due to javax.xml conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,10 @@
                     <groupId>org.hibernate.search</groupId>
                     <artifactId>hibernate-search-backend-elasticsearch</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xpp3</groupId>
+                    <artifactId>xpp3</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Java 11 will complain due to xpp3 having a copy of javax.xml. This fix allows debugging in visual studio code.

https://stackoverflow.com/questions/62913587/duplicate-jars-in-java-11-causing-below-error