### PR TITLE
PR-570 Cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect(robot).md
+++ b/.github/ISSUE_TEMPLATE/defect(robot).md
@@ -8,34 +8,40 @@ labels: bug
 
 ## Test Case/s To Reproduce Issue
 
-```
 # path to test case
-tests/robot/CONTRIBUTION_TESTS/...
-```
 
-```
-# robot command to execute related test case(s) in your terminal/console
+fhir-bridge/tests/robot/...
+fhir-bridge/tests/robot/...
+fhir-bridge/tests/robot/...
+
+
+# Using test data from:
+
+fhir-bridge/src/test/resources/...
+fhir-bridge/src/test/resources/...
+fhir-bridge/src/test/resources/...
+
 
 # by test case name (wildcards possible)
-robot -t "*Bug Case 01*" -d results -L TRACE robot/TEST_SUITE FOLDER
 
-# by tag
-robot -i failing -d results -L TRACE robot/TEST_SUITE_FOLDER
+e.g.
+008 Create Body Height
+012 Create Body Weight
+008 Create History of Travel (invalid/missing 'component[0] start date')
 
-# Valid test suite folder names
-COMPOSITION_TESTS
-CONTRIBUTION_TESTS
-DIRECTORY_TESTS
-EHR_SERVICE_TESTS
-EHR_STATUS_TESTS
-KNOWLEDGE_TESTS
-QUERY_SERVICE_TESTS
-```
+
+# robot command to execute related test case(s) in your terminal/console
+
+robot -d results -L TRACE (PARAMETERS) robot
+
+
+# Description
+
+
 
 ## Actual Result
 
 foo
-
 
 ## Expected Result
 

--- a/tests/robot/DIAGNOSTIC/01_create.robot
+++ b/tests/robot/DIAGNOSTIC/01_create.robot
@@ -19,6 +19,7 @@
 
 *** Settings ***
 Resource                ${EXECDIR}/robot/_resources/suite_settings.robot
+Resource    ../_resources/keywords/generic.robot
 
 Test Setup              generic.prepare new request session    Prefer=return=representation
 ...                                                            Authorization=${AUTHORIZATION['Authorization']}
@@ -55,11 +56,12 @@ Force Tags              diagnostic_create    create
     ...                 4. *POST* example JSON to diagnostic endpoint\n\n
 	...                 5. *VALIDATE* the response status \n\n
     ...                 6. *VALIDATE* outcome against diagnostic text
-    [Tags]              diagnostic-report    valid
+    [Tags]              diagnostic-report    invalid    not-ready   not-ready_bug
 
     ehr.create new ehr                      000_ehr_status.json
     diagnostic.create diagnostic report     create-diagnosticReport-without-observation.json 
-    diagnostic.validate response - 201
+    validate response - 422 (missing observation)
+    [Teardown]  TRACE GITHUB ISSUE    574   bug
 
 
 003 Create Diagnostic Report Using Default Profile
@@ -69,7 +71,7 @@ Force Tags              diagnostic_create    create
     ...                 4. *POST* example JSON to diagnostic endpoint\n\n
 	...                 5. *VALIDATE* the response status \n\n
     ...                 6. *VALIDATE* outcome against diagnostic text
-    [Tags]              invalid
+    [Tags]              diagnostic-report   invalid
 
     ehr.create new ehr                      000_ehr_status.json
     diagnostic.create diagnostic report     create-diagnosticReport-with-default-profile.json 
@@ -83,7 +85,7 @@ Force Tags              diagnostic_create    create
     ...                 4. *POST* example JSON to diagnostic endpoint\n\n
 	...                 5. *VALIDATE* the response status \n\n
     ...                 6. *VALIDATE* outcome against diagnostic text
-    [Tags]              invalid
+    [Tags]              diagnostic-report    invalid
 
     ehr.create new ehr                      000_ehr_status.json
     diagnostic.create diagnostic report     create-diagnosticReport-hls-genetics-result.json 


### PR DESCRIPTION
[CHANGE] Adjusted Robot Issue template 
[ADD] Tags `diagnostic-report`
[ADD] Bug Trace for failing Diagnostic Report Test `002 Create Diagnostic Report w/o Observation`
https://github.com/ehrbase/fhir-bridge/issues/574

NOTE: This Test will fail and be skipped in the CI until a fix is provided; it falls under the label `--skiponfailure not-ready`